### PR TITLE
Refactor making Shim a class

### DIFF
--- a/lib/mod.js
+++ b/lib/mod.js
@@ -10,10 +10,10 @@ if (thisModuleURL.searchParams.has('props')) {
 }
 
 let s = new Shim(shimedGlobals);
-s.apply();
 let shim = s.shim.bind(s);
 let unshim = s.unshim.bind(s);
 
+s.apply();
 if (thisModuleURL.searchParams.has('global')) {
   shim();
 }

--- a/lib/mod.js
+++ b/lib/mod.js
@@ -1,4 +1,4 @@
-import Shim, { domShimSymbol, defaultGlobals } from './shim.js';
+import setupShim, { domShimSymbol, defaultGlobals } from './shim.js';
 
 const thisModuleURL = new URL(import.meta.url);
 
@@ -9,7 +9,7 @@ if (thisModuleURL.searchParams.has('props')) {
   shimedGlobals = defaultGlobals;
 }
 
-const { shim, unshim } = Shim(shimedGlobals);
+let { shim, unshim } = setupShim(shimedGlobals);
 
 if (thisModuleURL.searchParams.has('global')) {
   shim();

--- a/lib/mod.js
+++ b/lib/mod.js
@@ -1,4 +1,4 @@
-import setupShim, { domShimSymbol, defaultGlobals } from './shim.js';
+import { domShimSymbol, defaultGlobals, Shim } from './shim.js';
 
 const thisModuleURL = new URL(import.meta.url);
 
@@ -9,7 +9,10 @@ if (thisModuleURL.searchParams.has('props')) {
   shimedGlobals = defaultGlobals;
 }
 
-let { shim, unshim } = setupShim(shimedGlobals);
+let s = new Shim(shimedGlobals);
+s.apply();
+let shim = s.shim.bind(s);
+let unshim = s.unshim.bind(s);
 
 if (thisModuleURL.searchParams.has('global')) {
   shim();

--- a/lib/patch.js
+++ b/lib/patch.js
@@ -1,0 +1,85 @@
+function patchText(window) {
+  // Patch Text
+  let aTextNode = window.document.createTextNode('');
+  let ConstructibleText = aTextNode.constructor.bind(null, window.document);
+  return ConstructibleText;
+}
+
+function patchNodeType(window, ConstructibleText) {
+  // Patch Node
+  const CharacterData = Object.getPrototypeOf(ConstructibleText);
+  const Node = Object.getPrototypeOf(CharacterData);
+  const EventTarget = Object.getPrototypeOf(Node);
+
+  const ntSymbol = Symbol('dom-shim.nodeType');
+  class PatchedNode extends EventTarget {
+    constructor() {
+      super();
+
+      Object.defineProperty(this, 'nodeType', {
+        get() {
+          return this[ntSymbol];
+        },
+        set(val) {
+          this[ntSymbol] = val;
+        },
+      });
+    }
+  }
+
+  Object.setPrototypeOf(Node, PatchedNode);
+  Object.setPrototypeOf(Node.prototype, PatchedNode.prototype);
+}
+
+function patchRAF() {
+  // Patch requestAnimationFrame
+  let lastTime = 0;
+  function requestAnimationFrame(callback, _element) {
+    var currTime = new Date().getTime();
+    var timeToCall = Math.max(0, 16 - (currTime - lastTime));
+    var id = setTimeout(function () {
+      callback(currTime + timeToCall);
+    }, timeToCall);
+    lastTime = currTime + timeToCall;
+    return id;
+  }
+  return requestAnimationFrame;
+}
+
+function patchDefaultView(window, { requestAnimationFrame, Text }) {
+  const dfDescriptor = Object.getOwnPropertyDescriptor(
+    window.Document.prototype,
+    'defaultView'
+  );
+  Object.defineProperty(window.Document.prototype, 'defaultView', {
+    get() {
+      let window = dfDescriptor.get.call(this);
+
+      return new Proxy(window, {
+        get(window, name) {
+          switch (name) {
+            case 'Text':
+              return Text;
+            case 'requestAnimationFrame':
+              return requestAnimationFrame;
+          }
+          return window[name];
+        },
+      });
+    },
+  });
+}
+
+export function apply(window) {
+  const ConstructibleText = patchText(window);
+  patchNodeType(window, ConstructibleText);
+  const requestAnimationFrame = patchRAF();
+
+  patchDefaultView(window, {
+    requestAnimationFrame,
+    Text: ConstructibleText
+  });
+
+  // Patch HTMLElement
+  delete window.HTMLElement.observedAttributes;
+}

--- a/lib/shim.js
+++ b/lib/shim.js
@@ -1,4 +1,5 @@
 import { parseHTML } from 'https://unpkg.com/linkedom@0.11.0/worker.js';
+import { apply as applyPatches } from './patch.js';
 
 export const domShimSymbol = Symbol.for('dom-shim.defaultView');
 export const defaultGlobals = Object.freeze([
@@ -9,78 +10,14 @@ export const defaultGlobals = Object.freeze([
 
 const dontShimIfExists = new Set(['window']);
 
-export default function (shimedGlobals = Object.freeze([])) {
+export default function(shimedGlobals = Object.freeze([])) {
   let parsed = parseHTML(`
     <html lang="en">
     <head><title>Site</title></head>
     <body></body>
     </html>
   `);
-
-  // Patch Text
-  let aTextNode = parsed.document.createTextNode('');
-  let ConstructibleText = aTextNode.constructor.bind(null, parsed.document);
-
-  // Patch Node
-  const CharacterData = Object.getPrototypeOf(ConstructibleText);
-  const Node = Object.getPrototypeOf(CharacterData);
-  const EventTarget = Object.getPrototypeOf(Node);
-
-  const ntSymbol = Symbol('dom-shim.nodeType');
-  class PatchedNode extends EventTarget {
-    constructor() {
-      super();
-
-      Object.defineProperty(this, 'nodeType', {
-        get() {
-          return this[ntSymbol];
-        },
-        set(val) {
-          this[ntSymbol] = val;
-        },
-      });
-    }
-  }
-
-  Object.setPrototypeOf(Node, PatchedNode);
-  Object.setPrototypeOf(Node.prototype, PatchedNode.prototype);
-
-  // Patch requestAnimationFrame
-  let lastTime = 0;
-  function requestAnimationFrame(callback, element) {
-    var currTime = new Date().getTime();
-    var timeToCall = Math.max(0, 16 - (currTime - lastTime));
-    var id = setTimeout(function () {
-      callback(currTime + timeToCall);
-    }, timeToCall);
-    lastTime = currTime + timeToCall;
-    return id;
-  }
-
-  const dfDescriptor = Object.getOwnPropertyDescriptor(
-    parsed.Document.prototype,
-    'defaultView'
-  );
-  Object.defineProperty(parsed.Document.prototype, 'defaultView', {
-    get() {
-      let window = dfDescriptor.get.call(this);
-
-      return new Proxy(window, {
-        get(window, name) {
-          switch (name) {
-            case 'Text':
-              return ConstructibleText;
-            case 'requestAnimationFrame':
-              return requestAnimationFrame;
-          }
-          return window[name];
-        },
-      });
-    },
-  });
-
-  // Patch HTMLElement
-  delete parsed.HTMLElement.observedAttributes;
+  applyPatches(parsed);
 
   const window = parsed.document.defaultView;
 
@@ -113,6 +50,6 @@ export default function (shimedGlobals = Object.freeze([])) {
 
   return {
     shim,
-    unshim,
+    unshim
   };
 }

--- a/lib/shim.js
+++ b/lib/shim.js
@@ -10,46 +10,53 @@ export const defaultGlobals = Object.freeze([
 
 const dontShimIfExists = new Set(['window']);
 
-export default function(shimedGlobals = Object.freeze([])) {
-  let parsed = parseHTML(`
-    <html lang="en">
-    <head><title>Site</title></head>
-    <body></body>
-    </html>
-  `);
-  applyPatches(parsed);
+export class Shim {
+  constructor(shimedGlobals = Object.freeze([])) {
+    this.globals = shimedGlobals;
+    this.setup();
+  }
 
-  const window = parsed.document.defaultView;
+  setup() {
+    let parsed = parseHTML(`
+      <html lang="en">
+      <head><title>Site</title></head>
+      <body></body>
+      </html>
+    `);
+    applyPatches(parsed);
 
-  let shimValues = Object.create(null);
-  for (let name of shimedGlobals) {
-    if (dontShimIfExists.has(name) && name in globalThis) {
-      continue;
+    const window = parsed.document.defaultView;
+
+    let shimValues = this.values = Object.create(null);
+    for (let name of this.globals) {
+      if (dontShimIfExists.has(name) && name in globalThis) {
+        continue;
+      }
+      Reflect.set(shimValues, name, window[name]);
     }
-    Reflect.set(shimValues, name, window[name]);
   }
 
-  Object.defineProperty(globalThis, domShimSymbol, {
-    enumerable: false,
-    writable: true,
-    configurable: true,
-    value: shimValues,
-  });
-
-  function shim() {
-    Object.assign(globalThis, shimValues);
+  apply() {
+    Object.defineProperty(globalThis, domShimSymbol, {
+      enumerable: false,
+      writable: true,
+      configurable: true,
+      value: this.values,
+    });
   }
 
-  function unshim() {
-    for (let name of shimedGlobals) {
-      if (globalThis[name] === shimValues[name]) {
+  shim() {
+    if(!(domShimSymbol in globalThis))
+      this.apply();
+
+    Object.assign(globalThis, this.values);
+  }
+
+  unshim() {
+    for (let name of this.globals) {
+      if (globalThis[name] === this.values[name]) {
         delete globalThis[name];
       }
     }
   }
-
-  return {
-    shim,
-    unshim
-  };
 }

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,21 @@ You can specify *which* DOM globals are added by adding a comma-separated `props
 import 'https://cdn.spooky.click/dom-shim/1.2.0/mod.js?global&props=HTMLDivElement,HTMLParagraphElement,customElements';
 ```
 
+### Side-effect free entry point
+
+If your runtime does not support query params (most bundlers) or you do not want the side-effect to take place immediate, you can use the other entry point `shim.js` like so:
+
+```js
+import setupShim from 'https://cdn.spooky.click/dom-shim/1.2.0/shim.js';
+
+let { shim, unshim } = setupShim();
+
+// If you want the globals to be applied:
+shim();
+```
+
+Calling `setupShim` will create the shimmed environment and set it on the `Symbol.for('dom-shim.defaultView')` property. Calling the returned `shim()` will apply the globals onto the environments `globalThis`.
+
 ## License
 
 BSD-2-Clause

--- a/readme.md
+++ b/readme.md
@@ -39,15 +39,21 @@ import 'https://cdn.spooky.click/dom-shim/1.2.0/mod.js?global&props=HTMLDivEleme
 If your runtime does not support query params (most bundlers) or you do not want the side-effect to take place immediate, you can use the other entry point `shim.js` like so:
 
 ```js
-import setupShim from 'https://cdn.spooky.click/dom-shim/1.2.0/shim.js';
+import { Shim } from 'https://cdn.spooky.click/dom-shim/1.2.0/shim.js';
 
-let { shim, unshim } = setupShim();
+let s = new Shim(['document']);
+console.log(s.values); // { document }
 
-// If you want the globals to be applied:
-shim();
+// To apply the shim symbol to the global environment
+s.apply();
+
+// If you want the globals to be set on the global environment
+s.shim();
 ```
 
-Calling `setupShim` will create the shimmed environment and set it on the `Symbol.for('dom-shim.defaultView')` property. Calling the returned `shim()` will apply the globals onto the environments `globalThis`.
+Creating a new `Shim` instance will create the shimmed environment. Calling `s.apply()` will set the environment on the `Symbol.for('dom-shim.defaultView')` property. Calling `s.shim()` will apply the globals onto the environments `globalThis`.
+
+> Note: if you call `.shim()` then you do not need to also call `.apply()`.
 
 ## License
 

--- a/test/mod.test.js
+++ b/test/mod.test.js
@@ -1,0 +1,70 @@
+import { domShimSymbol } from '../lib/mod.js?props=document,HTMLElement,requestAnimationFrame,Text';
+import { assertEquals } from './deps.js';
+
+Deno.test('Text can be extended from the defaultView', () => {
+  const { Text } = self[domShimSymbol].document.defaultView;
+  class Mark extends Text {
+    get nodeType() {
+      return -1;
+    }
+  }
+
+  let mark = new Mark();
+  assertEquals(mark.data, '');
+});
+
+Deno.test('Text can be extended from the root', () => {
+  const { Text } = self[domShimSymbol];
+  class Mark extends Text {
+    get nodeType() {
+      return -1;
+    }
+  }
+
+  let mark = new Mark();
+  assertEquals(mark.data, '');
+});
+
+Deno.test('Text can be inserted into DOM', () => {
+  const { document, Text } = self[domShimSymbol];
+  let div = document.createElement('div');
+  let text = new Text();
+  div.append(text);
+  assertEquals(div.firstChild.nodeType, 3);
+});
+
+Deno.test('Extended Text can set its data', () => {
+  const { Text } = self[domShimSymbol];
+  class Mark extends Text {
+    constructor(...args) {
+      super(...args);
+      this.data = 'works';
+    }
+
+    get nodeType() {
+      return -1;
+    }
+  }
+  let mark = new Mark();
+  assertEquals(mark.data, 'works');
+});
+
+Deno.test('HTMLElement.observedAttributes is undefined', () => {
+  const { HTMLElement } = self[domShimSymbol];
+  assertEquals(HTMLElement.observedAttributes, undefined);
+});
+
+Deno.test('requestAnimationFrame can be used', async () => {
+  let r;
+  let p = new Promise(rr => { r = rr; });
+
+  const { requestAnimationFrame } = self[domShimSymbol];
+  let worked = false;
+  requestAnimationFrame(() => {
+    worked = true;
+    r();
+  });
+
+  await p;
+  assertEquals(worked, true);
+});

--- a/test/shim.test.js
+++ b/test/shim.test.js
@@ -1,70 +1,8 @@
-import { domShimSymbol } from '../lib/mod.js?props=document,HTMLElement,requestAnimationFrame,Text';
-import { assertEquals } from './deps.js';
+import setupShim, { domShimSymbol } from '../lib/shim.js';
+import { assert } from './deps.js';
 
-Deno.test('Text can be extended from the defaultView', () => {
-  const { Text } = self[domShimSymbol].document.defaultView;
-  class Mark extends Text {
-    get nodeType() {
-      return -1;
-    }
-  }
-
-  let mark = new Mark();
-  assertEquals(mark.data, '');
-});
-
-Deno.test('Text can be extended from the root', () => {
-  const { Text } = self[domShimSymbol];
-  class Mark extends Text {
-    get nodeType() {
-      return -1;
-    }
-  }
-
-  let mark = new Mark();
-  assertEquals(mark.data, '');
-});
-
-Deno.test('Text can be inserted into DOM', () => {
-  const { document, Text } = self[domShimSymbol];
-  let div = document.createElement('div');
-  let text = new Text();
-  div.append(text);
-  assertEquals(div.firstChild.nodeType, 3);
-});
-
-Deno.test('Extended Text can set its data', () => {
-  const { Text } = self[domShimSymbol];
-  class Mark extends Text {
-    constructor(...args) {
-      super(...args);
-      this.data = 'works';
-    }
-
-    get nodeType() {
-      return -1;
-    }
-  }
-  let mark = new Mark();
-  assertEquals(mark.data, 'works');
-});
-
-Deno.test('HTMLElement.observedAttributes is undefined', () => {
-  const { HTMLElement } = self[domShimSymbol];
-  assertEquals(HTMLElement.observedAttributes, undefined);
-});
-
-Deno.test('requestAnimationFrame can be used', async () => {
-  let r;
-  let p = new Promise(rr => { r = rr; });
-
-  const { requestAnimationFrame } = self[domShimSymbol];
-  let worked = false;
-  requestAnimationFrame(() => {
-    worked = true;
-    r();
-  });
-
-  await p;
-  assertEquals(worked, true);
+Deno.test('Takes globals', async () => {
+  setupShim(['document']);
+  let root = globalThis[domShimSymbol];
+  assert(root.document, 'document shimed');
 });

--- a/test/shim.test.js
+++ b/test/shim.test.js
@@ -1,8 +1,7 @@
-import setupShim, { domShimSymbol } from '../lib/shim.js';
+import { domShimSymbol, Shim } from '../lib/shim.js';
 import { assert } from './deps.js';
 
 Deno.test('Takes globals', async () => {
-  setupShim(['document']);
-  let root = globalThis[domShimSymbol];
-  assert(root.document, 'document shimed');
+  let s = new Shim(['document']);
+  assert(s.values.document, 'document shimed');
 });


### PR DESCRIPTION
This does 2 things:

- `Shim` is now a class, which you can instantiate to a side-effect free environment.
  - Calling `.shim()` on the instance will apply to the globals.
- The DOM patching was moved to a separate module for better organization.