### PR TITLE
Update to linkedom v0.12.0

### DIFF
--- a/lib/shim.js
+++ b/lib/shim.js
@@ -1,4 +1,4 @@
-import { parseHTML } from 'https://unpkg.com/linkedom@0.11.0/worker.js';
+import { parseHTML } from 'https://unpkg.com/linkedom@0.12.0/worker.js';
 import { apply as applyPatches } from './patch.js';
 
 export const domShimSymbol = Symbol.for('dom-shim.defaultView');


### PR DESCRIPTION
The linkedom update includes a change that preserves attribute name case, which enables downstream libraries to have attribute names such as `.firstName` that are not lowercased to `.firstname`